### PR TITLE
Update background map and style

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -1,11 +1,10 @@
 html, body {
-	height: 100%;
-	margin: 0;
-	padding: 0;
-	font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", sans-serif;
-	font-weight: 300;
-	background: #FFF;
-	color: #333;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        background: #f4f4f4;
+        color: #222;
 }
 
 #map_canvas {
@@ -17,15 +16,15 @@ html, body {
 }
 
 #quiz {
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	text-align: right;
-	height: 4em;
-	text-align: center;
-	border-bottom: 1px solid #333;
-	box-sizing: border-box;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        text-align: center;
+        height: 4em;
+        border-bottom: 1px solid #ccc;
+        background: rgba(255,255,255,0.8);
+        box-sizing: border-box;
 }
 
 p {
@@ -42,6 +41,6 @@ p {
 }
 
 a, a:visited {
-	color: #0099ff;
-	text-decoration: none;
+        color: #0077cc;
+        text-decoration: none;
 }

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Mercator Puzzle Redux</title>
     <link href="https://unpkg.com/leaflet/dist/leaflet.css" rel="stylesheet" />
     <link href="css/default.css" rel="stylesheet" />

--- a/js/puzzle.js
+++ b/js/puzzle.js
@@ -122,13 +122,31 @@ document.addEventListener('DOMContentLoaded', () => {
     worldCopyJump: true,
   });
 
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; OpenStreetMap contributors',
-  }).addTo(map);
+  const Esri_WorldShadedRelief = L.tileLayer(
+    'https://server.arcgisonline.com/ArcGIS/rest/services/{variant}/MapServer/tile/{z}/{y}/{x}',
+    {
+      variant: 'World_Shaded_Relief',
+      attribution: 'Tiles &copy; Esri &mdash; Source: Esri',
+      maxZoom: 13,
+      subdomains: ['a', 'b', 'c'],
+      minZoom: 0,
+    },
+  );
+  Esri_WorldShadedRelief.addTo(map);
 
   fetch('data/countries.geo.json')
     .then((r) => r.json())
     .then((data) => {
+      L.geoJSON(data, {
+        style: {
+          color: '#ffffff',
+          weight: 1,
+          opacity: 0.5,
+          fillOpacity: 0,
+        },
+        interactive: false,
+      }).addTo(map);
+
       const countriesToShow = getRandomIndexes(15, data.features.length);
       let totalScore = 0;
 


### PR DESCRIPTION
## Summary
- modernize layout and typography
- switch to Esri World Shaded Relief basemap
- draw world borders in white for reference

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861b97e9be483279583c5ea6a8db0e2