### PR TITLE
Fix dragging and remove title

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
 <body>
     <div id="map_canvas"></div>
     <div id="quiz">
-        <p><strong>Mercator Puzzle Redux &mdash; by <a href="http://www.bram.us/">Bramus!</a></strong></p>
         <p id="message">Drag the shapes to their correct location. If you don't know the position of a country, double click it to let the computer place it. Hit refresh to get a new set of shapes.</p>
         <span id="score">0/15</span>
     </div>

--- a/js/puzzle.js
+++ b/js/puzzle.js
@@ -88,6 +88,7 @@ function enableDrag(poly, map) {
   }
   function onUp() {
     if (!start) return;
+    map.dragging.enable();
     map.off('mousemove', onMove);
     map.off('mouseup', onUp);
     start = null;
@@ -96,6 +97,10 @@ function enableDrag(poly, map) {
   poly.on('mousedown', (e) => {
     start = e.latlng;
     initial = poly.getLatLngs().map((r) => r.map((p) => ({ lat: p.lat, lng: p.lng })));
+    map.dragging.disable();
+    if (e.originalEvent) {
+      L.DomEvent.stopPropagation(e);
+    }
     map.on('mousemove', onMove);
     map.on('mouseup', onUp);
   });


### PR DESCRIPTION
## Summary
- remove the Bramus! header from the page
- disable map dragging when moving countries so polygons can be dragged

## Testing
- `npm test` *(fails: package.json missing)*
- `npx eslint js/puzzle.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6861bb0b2f6883279148cb4fb595411a